### PR TITLE
Styling for message text

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,7 +61,7 @@ class SnackbarComponent extends Component {
             this.setState({ hideDistance: event.nativeEvent.layout.height });
           }}
         >
-          <Text style={[styles.text_msg, { color: this.props.messageColor }]}>{this.props.textMessage}</Text>
+          <Text style={this.props.messageStyle || [styles.text_msg, { color: this.props.messageColor }]}>{this.props.textMessage}</Text>
           {this.props.actionHandler && this.props.actionText &&
             <Touchable onPress={() => { this.props.actionHandler(); }} >
               <Text style={this.props.accentStyle || [styles.action_text, { color: this.props.accentColor }]}>{this.props.actionText.toUpperCase()}</Text>
@@ -153,6 +153,7 @@ SnackbarComponent.propTypes = {
   accentColor: PropTypes.string,
   messageColor: PropTypes.string,
   accentStyle: PropTypes.object,
+  messageStyle: PropTypes.object,
   backgroundColor: PropTypes.string,
   distanceCallback: PropTypes.func,
   onHide: PropTypes.func,


### PR DESCRIPTION
Dodanie atrybutu `messageStyle`, żeby wyrównać wysokości snackbarów z i bez `accentText`